### PR TITLE
Tweak to .gitignore for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,9 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+##################
+## User Changes ##
+##################
+BotConfig.json
+.vscode/


### PR DESCRIPTION
Apparently I never added the ignore BotConfig.json line either, so I've added both that and the .VSCode project folder to the ignore list.